### PR TITLE
Avoid bug where dash is called in Ubuntu

### DIFF
--- a/bin/git/hooks-wrapper
+++ b/bin/git/hooks-wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Runs all executable pre-commit-* hooks and exits after,
 # if any of them was not successful.


### PR DESCRIPTION
Default ubuntu installations may symlink /bin/sh to dash, which will cause an error on initialization of the exitcodes array. Explicitly call bash to avoid this. Ref: http://stackoverflow.com/questions/18921350/shell-script-correct-way-to-declare-an-empty-array
