### PR TITLE
Parameters are not passed down to called hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Want to make sure everyone in your project is using a githook?
 
 ## install
-- Copy the `bin/git/hooks-wrapper` and `bin/git/inti-hooks` scripts to your project
+- Copy the `bin/git/hooks-wrapper` and `bin/git/init-hooks` scripts to your project
 - If you change the location of these scripts in your project you will need to edit the paths in the scripts slightly
 
 ## usage

--- a/bin/git/hooks-wrapper
+++ b/bin/git/hooks-wrapper
@@ -22,14 +22,14 @@ NATIVE_HOOKS_DIR=$(git rev-parse --show-toplevel)/.git/hooks
 
 for hook in $CUSTOM_HOOKS_DIR/$(basename $0)-*; do
   test -x "$hook" || continue
-  out=`$hook`
+  out=`$hook "$@"`
   exitcodes+=($?)
   echo "$out"
 done
 
 # check if there was a local hook that was moved previously
 if [ -f "$NATIVE_HOOKS_DIR/$hookname.local" ]; then
-    out=`$NATIVE_HOOKS_DIR/$hookname.local`
+    out=`$NATIVE_HOOKS_DIR/$hookname.local "$@"`
     exitcodes+=($?)
     echo "$out"
 fi


### PR DESCRIPTION
For example the `commit-msg`hooks receives as first parameter the file which contains the message. 
